### PR TITLE
Forge User-Agent in login sequence

### DIFF
--- a/src/main/java/com/xiaomitool/v2/gui/controller/LoginController.java
+++ b/src/main/java/com/xiaomitool/v2/gui/controller/LoginController.java
@@ -202,6 +202,7 @@ private static final String LOGIN_URL = "https://account.xiaomi.com/pass/service
         BROWSER_AREA = new VisiblePane(CONTENT);
         BROWSER_AREA.add(LOADING_NODE);
         ENGINE = BROWSER.getEngine();
+        ENGINE.setUserAgent("miNative/1.0");
         ENGINE.load(LOGIN_URL);
         Pointer pointer = new Pointer();
         pointer.pointed = new CookieUtils.EventCookieAdd() {


### PR DESCRIPTION
 * The Mi Unlock app sends web requests with `miNative/1.0` user agent string.
 * Simulate this so that the server would send confirmation codes. If we don't, user is unable to login.